### PR TITLE
Select RSA signature scheme as specified by SignerOpts if applicable

### DIFF
--- a/tpm.go
+++ b/tpm.go
@@ -175,6 +175,15 @@ func (t TPM) Sign(rr io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, 
 		if err != nil {
 			return nil, fmt.Errorf("signer: can't error getting rsa details %v", err)
 		}
+		sigScheme := tpm2.TPMAlgRSASSA
+		if opts != nil {
+			// Signature algorithm specified by SignerOpts -> use that
+			if _, ok := opts.(*rsa.PSSOptions); ok {
+				sigScheme = tpm2.TPMAlgRSAPSS
+			} // else keep tpm2.TPMAlgRSASSA
+		} else if rd.Scheme.Scheme != tpm2.TPMAlgNull {
+			sigScheme = rd.Scheme.Scheme
+		}
 		rspSign, err := tpm2.Sign{
 			KeyHandle: tpm2.AuthHandle{
 				Handle: t.Handle,
@@ -186,8 +195,8 @@ func (t TPM) Sign(rr io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, 
 				Buffer: digest[:],
 			},
 			InScheme: tpm2.TPMTSigScheme{
-				Scheme: rd.Scheme.Scheme,
-				Details: tpm2.NewTPMUSigScheme(rd.Scheme.Scheme, &tpm2.TPMSSchemeHash{
+				Scheme: sigScheme,
+				Details: tpm2.NewTPMUSigScheme(sigScheme, &tpm2.TPMSSchemeHash{
 					HashAlg: algid,
 				}),
 			},


### PR DESCRIPTION
This change takes two previously uncovered conditions into account for RSA key based signatures:
1. The signature scheme of an RSA key might be TPMAlgNull, which cannot be used as input for the TPM2_Sign-command. In that case a real default value must be picked.
2. In the context of setting up a TLS connection, the signature scheme is not a free choice of the implementation: it is the crypto/tls library that dictates which scheme to use (AFAIK RSASSA for TLS v1.2 and RSAPSS for TLS v1.3) via the SignerOpts  argument (in a very weird way though: you have to check whether SignerOpts is actually a rsa.PSSOptions). Using a different scheme than the one specified, results in an incorrect signature that cannot be decrypted/verified by the peer.